### PR TITLE
Add conditional basic auth to nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,13 @@ COPY . .
 RUN bundle exec nanoc compile
 
 FROM nginx:stable
+# Install htpasswd command
+RUN apt-get update -yqq && apt-get install -yqq apache2-utils
+
 COPY default.conf.template /etc/nginx/conf.d/default.conf.template
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY --from=build /app/output/ /usr/share/nginx/html/
+COPY http_basic_auth.sh http_basic_auth.sh
+
+ENTRYPOINT ["./http_basic_auth.sh"]
 CMD /bin/bash -c "envsubst '\$PORT' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf" && nginx -g 'daemon off;'

--- a/http_basic_auth.sh
+++ b/http_basic_auth.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+# If the basic auth environment variables are present update default.conf to
+# require basic auth.
+if [ $BASIC_AUTH_USERNAME ] && [ $BASIC_AUTH_PASSWORD ]; then
+  sed -i 's/location \/ {/location \/ {\
+    auth_basic "Restricted";\
+    auth_basic_user_file \/etc\/nginx\/.htpasswd;\
+/' /etc/nginx/conf.d/default.conf.template
+
+  htpasswd -bc /etc/nginx/.htpasswd $BASIC_AUTH_USERNAME $BASIC_AUTH_PASSWORD
+fi
+
+exec "$@"


### PR DESCRIPTION
If the `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` environment variables
are set then basic auth will be enabled in nginx, otherwise there's no
basic auth.

```
docker run \
-e PORT=8080 \ 
-e BASIC_AUTH_USERNAME=test \
-e BASIC_AUTH_PASSWORD=test \
-p 3000:8080 \
--rm -it dfe-content-prototype
```

testing: wait for the review app to build, view the review app you should be prompted for basic auth crredentials.
un/pw `dfe-content-prototype`

edit:
for some reason github isn't picking up the review app, [here's the link](https://dfe-content-basic-auth-3xrgbi2.herokuapp.com/)