### PR TITLE
Add .govuk-link to link_to if no class supplied

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -1,3 +1,6 @@
+Dir.glob(File.join('./lib', '**', '*.rb')).sort.each { |f| require f }
+
 use_helper Nanoc::Helpers::Rendering
 use_helper Nanoc::Helpers::LinkTo
 use_helper Nanoc::Helpers::Breadcrumbs
+use_helper Helpers::LinkHelper

--- a/lib/helpers/link_helper.rb
+++ b/lib/helpers/link_helper.rb
@@ -1,0 +1,9 @@
+module Helpers
+  module LinkHelper
+    def link_to(*args, **kwargs)
+      return super if kwargs.has_key?('class')
+
+      super(*args, **kwargs.merge(class: 'govuk-link'))
+    end
+  end
+end


### PR DESCRIPTION
When `#link_to` is used without specifying a class links don't look right, the need the `.govuk-link` class. Rather than specify manually every time set it as the default; if other classes are provided they are used instead.