### PR TITLE
✨GovSpeak CMS Callouts

### DIFF
--- a/content/admin/govspeak-callout-example.js
+++ b/content/admin/govspeak-callout-example.js
@@ -1,0 +1,20 @@
+/* globals CMS:true */
+
+CMS.registerEditorComponent({
+  id: "callout-example",
+  label: "Callout Example",
+  fields: [{ name: "body", label: "Body", widget: "markdown" }],
+  pattern: /^\$E\n?(.*)\n?\$E$/,
+  fromBlock: function (match) {
+    return {
+      body: match[1],
+    };
+  },
+  toBlock: function (obj) {
+    return ["$E", obj.body, "$E"].join("\n");
+  },
+  toPreview: function (obj) {
+    var str = ['<div class="example">', obj.body, "</div>"].join("\n");
+    return str;
+  },
+});

--- a/content/admin/govspeak-callout-information.js
+++ b/content/admin/govspeak-callout-information.js
@@ -1,0 +1,26 @@
+/* globals CMS:true */
+
+CMS.registerEditorComponent({
+  id: "callout-information",
+  label: "Callout Information",
+  fields: [{ name: "body", label: "Body", widget: "markdown" }],
+  pattern: /^\^\n?(.*)\n?\^$/,
+  fromBlock: function (match) {
+    return {
+      body: match[1],
+    };
+  },
+  toBlock: function (obj) {
+    return ["^", obj.body, "^"].join("\n");
+  },
+  toPreview: function (obj) {
+    var str = [
+      '<div role="note" aria-label="Information" class="application-notice info-notice">',
+      "  <p>",
+      obj.body,
+      "  </p>",
+      "</div>",
+    ].join("\n");
+    return str;
+  },
+});

--- a/content/admin/govspeak-callout-warning.js
+++ b/content/admin/govspeak-callout-warning.js
@@ -1,0 +1,26 @@
+/* globals CMS:true */
+
+CMS.registerEditorComponent({
+  id: "callout-warning",
+  label: "Callout Warning",
+  fields: [{ name: "body", label: "Body", widget: "markdown" }],
+  pattern: /^%\n?(.*)\n?%$/,
+  fromBlock: function (match) {
+    return {
+      body: match[1],
+    };
+  },
+  toBlock: function (obj) {
+    return ["%", obj.body, "%"].join("\n");
+  },
+  toPreview: function (obj) {
+    var str = [
+      '<div role="note" aria-label="Warning" class="application-notice help-notice">',
+      "  <p>",
+      obj.body,
+      "  </p>",
+      "</div>",
+    ].join("\n");
+    return str;
+  },
+});

--- a/content/admin/index.html
+++ b/content/admin/index.html
@@ -12,5 +12,8 @@
   <script src="./govspeak-highlight-answer.js"></script>
   <script src="./govspeak-highlight-advisory.js"></script>
   <script src="./govspeak-highlight-statistic-headline.js"></script>
+  <script src="./govspeak-callout-example.js"></script>
+  <script src="./govspeak-callout-information.js"></script>
+  <script src="./govspeak-callout-warning.js"></script>
 </body>
 </html>

--- a/content/sample.gs
+++ b/content/sample.gs
@@ -4,6 +4,10 @@ title: 'Sample title'
 
 # This is a GovSpeak sample
 
+^This is an information callout^
+
+%This is a warning callout%
+
 $E
 **Example**: Open the pod bay doors
 $E


### PR DESCRIPTION
GovSpeak [Callouts](https://github.com/alphagov/govspeak#callouts)

* Callout Warning
* Callout Example
* Callout Information

Unfortunately, the inner markdown parsing is not supported just yet.  This might be related to https://github.com/netlify/netlify-cms/issues/1452 bug ticket about inner parsing widget parsing.

<img width="1504" alt="Screenshot 2020-04-03 11 54 51" src="https://user-images.githubusercontent.com/110469/78354911-a74ab980-75a4-11ea-9fd4-685bdb427708.png">
<img width="1504" alt="Screenshot 2020-04-03 12 14 05" src="https://user-images.githubusercontent.com/110469/78354919-ac0f6d80-75a4-11ea-8477-d7e8c8671925.png">
