### PR TITLE
Remove sublinks from the main index

### DIFF
--- a/content/index.slim
+++ b/content/index.slim
@@ -20,19 +20,3 @@ title: Home
 
     p.govuk-body
       | This collection of guidance and resources is for teachers, school leaders, parents and carers to support learning from home.
-
-    hr.govuk-section-break.govuk-section-break--xl.govuk-section-break--visible
-
-    h2.govuk-heading-m
-      == link_to(%{Support years 10 and 12 to continue to learn during coronavirus (COVID-19)}, '/support-years-10-and-12-to-continue-to-learn-during-coronavirus-covid-19-1/')
-
-    p.govuk-body
-      | This guidance is to help schools understand how best to support years 10 and 12 and plan for the 2020 to 2021 school year, following the closure of schools due to the coronavirus outbreak.
-
-    hr.govuk-section-break.govuk-section-break--xl.govuk-section-break--visible
-
-    h2.govuk-heading-m
-      == link_to(%{Use remote learning approaches during coronavirus (COVID-19)}, '/remote-teaching/use-remote-learning-approaches-during-coronavirus/')
-
-    p.govuk-body
-      | Add some text here


### PR DESCRIPTION
The extra links might cause confusion when this prototype is shared throughout the DfE. The content from these pages will (eventually) be 'merged' into the two existing paths; teachers and parents.

The content will still be accessible directly.

Now it looks like this, again

![Screenshot from 2020-04-08 14-16-07](https://user-images.githubusercontent.com/128088/78788312-8a96f300-79a3-11ea-80d0-cfb1ab4ebda5.png)
