### PR TITLE
🔧 Add basic auth on deploy

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -136,6 +136,9 @@ jobs:
         with:
           name: site
           path: ./output
+      - name: Create Staticfile.auth
+        run: |
+          echo "remote:$apr1$dcj56f7r$jJiPy3aUdhzSqIc7g6cs91" >> ./Staticfile.auth
       - name: Publish site
         uses: citizen-of-planet-earth/cf-cli-action@v1
         with: 


### PR DESCRIPTION
cloudfoundry [basic authentication setup](https://docs.cloudfoundry.org/buildpacks/staticfile/index.html#-basic-authentication)

