### PR TITLE
Add Staticfile.auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ output/*
 .eslintcache
 cypress/videos
 cypress/screenshots
-Staticfile.auth
 .byebug_history

--- a/Staticfile.auth
+++ b/Staticfile.auth
@@ -1,0 +1,1 @@
+remote:{SHA}6p/7brSl8Wf2op4RQLORZdR3NP0=


### PR DESCRIPTION
Staticfile.auth allows HTTP basic authentication to be set up. This is
needed so a member of the public doesn't accidentally happen across our
prototype and think it's _actually_ government advice, it's not for
security (as the code's usually on Github anyway).

https://docs.cloudfoundry.org/buildpacks/staticfile/index.html#basic-authentication