### PR TITLE
Fix CMS defs of info, warn and advice blocks

### DIFF
--- a/content/admin/govspeak-callout-information.js
+++ b/content/admin/govspeak-callout-information.js
@@ -4,14 +4,14 @@ CMS.registerEditorComponent({
   id: "callout-information",
   label: "Callout Information",
   fields: [{ name: "body", label: "Body", widget: "markdown" }],
-  pattern: /^\^\n?(.*)\n?\^$/,
+  pattern: /^\^(.*)\^$/,
   fromBlock: function (match) {
     return {
       body: match[1],
     };
   },
   toBlock: function (obj) {
-    return ["^", obj.body, "^"].join("\n");
+    return `^${obj.body}^`;
   },
   toPreview: function (obj) {
     var str = [

--- a/content/admin/govspeak-callout-warning.js
+++ b/content/admin/govspeak-callout-warning.js
@@ -4,14 +4,14 @@ CMS.registerEditorComponent({
   id: "callout-warning",
   label: "Callout Warning",
   fields: [{ name: "body", label: "Body", widget: "markdown" }],
-  pattern: /^%\n?(.*)\n?%$/,
+  pattern: /^%(.*)%$/,
   fromBlock: function (match) {
     return {
       body: match[1],
     };
   },
   toBlock: function (obj) {
-    return ["%", obj.body, "%"].join("\n");
+    return `%${obj.body}%`;
   },
   toPreview: function (obj) {
     var str = [

--- a/content/admin/govspeak-highlight-advisory.js
+++ b/content/admin/govspeak-highlight-advisory.js
@@ -4,14 +4,14 @@ CMS.registerEditorComponent({
   id: "highlight-advisory",
   label: "Highlight Advisory",
   fields: [{ name: "body", label: "Content", widget: "string" }],
-  pattern: /^@\n?(.*)\n?@$/,
+  pattern: /^@(.*)@$/,
   fromBlock: function (match) {
     return {
       body: match[1],
     };
   },
   toBlock: function (obj) {
-    return ["@", obj.body, "@"].join("\n");
+    return `@${obj.body}@`;
   },
   toPreview: function (obj) {
     var str = [


### PR DESCRIPTION
Govspeak advisories, warnings and information blocks differ from most of
their counterparts by being inline. This change removes the newlines
from the pattern regexp and fromBlock function to match the spec

https://github.com/alphagov/govspeak#information-callouts
https://github.com/alphagov/govspeak#warning-callouts
https://github.com/alphagov/govspeak#advisory