### PR TITLE
Add document status indicator

### DIFF
--- a/content/supporting-your-childrens-education-during-coronavirus.gs
+++ b/content/supporting-your-childrens-education-during-coronavirus.gs
@@ -1,6 +1,7 @@
 ---
 title: "Supporting your children's education during coronavirus (COVID-19)"
 lead_paragraph: "Information, guidance and support for parents and carers of children who are learning at home"
+status: published
 ---
 
 @This page and [information for teachers](/teachers) will be updated regularly to include further resources and reflect the latest information and developments.@

--- a/content/teachers.gs
+++ b/content/teachers.gs
@@ -1,5 +1,6 @@
 ---
 title: Remote education during coronavirus (COVID-19)
+status: published
 ---
 @This page and [information for parents](/supporting-your-childrens-education-during-coronavirus) will be updated regularly to include further resources and reflect the latest information and developments.@
 

--- a/content/teachers/help-with-technology.gs
+++ b/content/teachers/help-with-technology.gs
@@ -6,6 +6,7 @@ pagination:
   previous:
     path: /teachers/safeguarding-and-remote-teaching-during-coronavirus-covid-19/
     text: Safeguarding and remote education during coronavirus (COVID-19)
+status: published
 ---
 Schools and colleges will soon be able to get access to more remote education resources during the school closure period. The Department for Education is working in partnership with technology suppliers such as Google and Microsoft to provide:
 

--- a/content/teachers/safeguarding-and-remote-teaching-during-coronavirus-covid-19.gs
+++ b/content/teachers/safeguarding-and-remote-teaching-during-coronavirus-covid-19.gs
@@ -4,6 +4,7 @@ pagination:
   next:
     path: /teachers/help-with-technology/
     text: Get help with technology for remote education during coronavirus (COVID-19)
+status: published
 ---
 This guidance is to help schools and teachers support pupils' education at home during the coronavirus (COVID-19) outbreak. 
 

--- a/layouts/govspeak.slim
+++ b/layouts/govspeak.slim
@@ -8,6 +8,7 @@ html.govuk-template lang='en'
     .govuk-width-container
       == render '/partials/phase-banner.*'
       == render '/partials/breadcrumbs.*'
+      == render '/partials/status-indicator.*'
 
       main#main-content.govuk-main-wrapper
         .govuk-grid-row
@@ -26,6 +27,7 @@ html.govuk-template lang='en'
             main.gem-c-govspeak
               - if item[:lead_paragraph]
                 hr
+
               == yield
 
             - if item[:pagination]

--- a/layouts/partials/status-indicator.slim
+++ b/layouts/partials/status-indicator.slim
@@ -1,0 +1,8 @@
+- if item[:status]&.downcase != 'published'
+  .status-indicator
+    - if item[:status]&.downcase == 'research'
+      strong.govuk-tag.govuk-tag--yellow
+        | User Research
+    - else
+      strong.govuk-tag.govuk-tag--red
+        | Draft


### PR DESCRIPTION
Add a flag to the top of pages that indicates whether the content is draft, research or published.

![Screenshot from 2020-04-27 12-14-04](https://user-images.githubusercontent.com/128088/80367821-a6dfce80-8883-11ea-808b-e61504d5efe5.png)
