### PR TITLE
Minor fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN bundle
 COPY . .
 RUN bundle exec nanoc compile
 
-FROM nginx:stable
+FROM nginx:1.16.1
 # Install htpasswd command
 RUN apt-get update -yqq && apt-get install -yqq apache2-utils
 ENV PORT=80

--- a/Rules
+++ b/Rules
@@ -21,7 +21,7 @@ compile '/case-studies/**/*.gs' do
 end
 
 compile '/**/*.gs' do
-  filter :govspeak
+  filter :govspeak, toc_levels: [1, 2]
   layout '/govspeak.*'
   write item.identifier.without_ext + '/index.html'
 end

--- a/lib/filters/govspeak.rb
+++ b/lib/filters/govspeak.rb
@@ -1,5 +1,5 @@
 require 'govspeak'
 
-Nanoc::Filter.define(:govspeak) do |content, _params|
-  Govspeak::Document.new(content).to_html
+Nanoc::Filter.define(:govspeak) do |content, params|
+  Govspeak::Document.new(content, params).to_html
 end


### PR DESCRIPTION
Couple of minor fix.
We want to pass the params through to Govspeak filter so we can set TOC levels to only include h2s in the toc.
Pins nginx version, don't want to pull in any breaking changes when deploying