### PR TITLE
Make eslint ignore minified JavaScript files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
     "plugin:prettier/recommended",
     "plugin:cypress/recommended"
   ],
+  ignorePatterns: ["*.min.js"],
   rules: {
     semi: ["error", "always"],
     "prettier/prettier": ["error"],


### PR DESCRIPTION
There are a load of failures in the minified govuk frontend file.