### PR TITLE
Add images to case study layout

### DIFF
--- a/layouts/case-study.slim
+++ b/layouts/case-study.slim
@@ -50,6 +50,8 @@ html.govuk-template lang='en'
           .govuk-grid-column-two-thirds
 
             main.gem-c-govspeak.case-study-document
+              - if item[:case_study_image]
+                img src="/images/#{item[:case_study_image]}"
 
               == yield
 


### PR DESCRIPTION
Place the image in content/images then add `case_study_image:
name-of-image.ext` to the frontmatter in the case study.gs